### PR TITLE
Automatizaciones del project board (auto-add, In review, bloqueo de co-author IA)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
+          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}

--- a/.github/workflows/block-ai-coauthor.yml
+++ b/.github/workflows/block-ai-coauthor.yml
@@ -1,0 +1,27 @@
+name: Block AI co-author
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-commit-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject commits co-authored by Claude/Anthropic
+        run: |
+          set -e
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          BAD=$(git log "$BASE..$HEAD" --format="%H %B" | grep -iE "co-authored-by:.*claude|noreply@anthropic\.com" || true)
+          if [ -n "$BAD" ]; then
+            echo "Se encontraron commits con coautoria de Claude/Anthropic:"
+            echo "$BAD"
+            echo
+            echo "Sacá la línea 'Co-Authored-By: Claude ...' del mensaje del commit y volvé a pushear."
+            exit 1
+          fi

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -1,0 +1,59 @@
+name: Sync PR review status
+
+on:
+  pull_request:
+    types: [review_requested, review_request_removed]
+
+jobs:
+  set-in-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync project Status with review state
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          script: |
+            const projectId = "PVT_kwDOEjyD084BhtOr";
+            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
+            const statusOptionId = context.payload.action === "review_requested"
+              ? "5c347fba"  // In review
+              : "e4b255ff"; // In progress
+            const prNodeId = context.payload.pull_request.node_id;
+
+            const result = await github.graphql(
+              `query($prId: ID!) {
+                node(id: $prId) {
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                      }
+                    }
+                  }
+                }
+              }`,
+              { prId: prNodeId }
+            );
+
+            const item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+
+            if (!item) {
+              console.log("PR is not on project 3 yet, skipping.");
+              return;
+            }
+
+            await github.graphql(
+              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { projectV2Item { id } }
+              }`,
+              { project: projectId, item: item.id, field: statusFieldId, option: statusOptionId }
+            );
+
+            const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
+            console.log(`Status set to ${statusName} for PR #${context.payload.pull_request.number}`);


### PR DESCRIPTION
## Resumen
Incluye las 3 automatizaciones ya validadas/en validación en `jar_workshops`:

1. **Auto-add**: issues y PRs nuevos se agregan solos al project "JAR Challenge 2026" (project 3).
2. **Sync de review**: al pedir reviewer en un PR, el Status pasa a In review; al sacarlo, vuelve a In progress.
3. **Bloqueo de co-author IA**: falla el check si algún commit del PR tiene "Co-Authored-By: Claude" o noreply@anthropic.com.

Las automatizaciones 1 y 2 usan el PAT fine-grained guardado como secret de organización (`ORG_PROJECT_TOKEN`).

**Este PR queda en draft** hasta terminar de validar todo en `jar_workshops` — lo saco de draft cuando esté confirmado que funciona, para que ahí sí se pueda mergear.

## Test plan
- [x] Auto-add ya probado end-to-end en jar_workshops
- [x] Sync de review, pendiente de probar en jar_workshops
- [ ] Mergear una vez validado