### PR TITLE
ci: add hardware-free build and test workflow

### DIFF
--- a/.github/workflows/hardware-free-checks.yml
+++ b/.github/workflows/hardware-free-checks.yml
@@ -1,0 +1,108 @@
+name: Hardware-free checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hardware-free-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hardware-free:
+    name: ROS 2 Humble build and tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ros:humble-ros-base-jammy
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      ROS_DISTRO: humble
+      ROS_LOG_DIR: ${{ github.workspace }}/artifacts/ros-logs
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install workspace dependencies
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-colcon-common-extensions \
+            python3-rosdep
+          if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
+            rosdep init
+          fi
+          rosdep update --rosdistro humble
+          # astra_camera is a pinned Orbbec fork (physical_rosmaster.repos),
+          # not a resolvable rosdep key, and it's exec_depend-only for
+          # yahboomcar_astra: no hardware-free test imports or launches it
+          # (test_astra_launch.py only inspects a Node action object, never
+          # resolves the package). Skip it instead of vendoring the whole
+          # camera SDK into every CI run.
+          rosdep install \
+            --from-paths . \
+            --ignore-src \
+            --rosdistro humble \
+            --skip-keys astra_camera \
+            --default-yes
+          mkdir -p "${ROS_LOG_DIR}"
+
+      - name: Build the workspace
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build --symlink-install --event-handlers console_direct+
+
+      - name: Run package tests
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          source install/setup.bash
+          test_status=0
+          colcon test --packages-select \
+            laserscan_to_point_pulisher sllidar_ros2 yahboomcar_astra \
+            yahboomcar_base_node yahboomcar_bringup yahboomcar_ctrl \
+            yahboomcar_description yahboomcar_visual \
+            --event-handlers console_direct+ \
+            --return-code-on-test-failure \
+            || test_status=$?
+          colcon test-result --verbose
+          exit "${test_status}"
+
+      - name: Run standalone tool tests
+        shell: bash
+        # tools/test_rosmaster_v339_pty.py is intentionally excluded: it only
+        # runs against the real, unvendored Rosmaster_Lib.py via
+        # ROSMASTER_V339_SOURCE, which is not available here for licensing
+        # reasons (see CONTRIBUTING.md).
+        run: |
+          source /opt/ros/humble/setup.bash
+          export PYTHONPATH="${GITHUB_WORKSPACE}/yahboomcar_bringup:${GITHUB_WORKSPACE}/tools:${PYTHONPATH}"
+          python3 -m pytest -q \
+            tools/test_rosmaster_lib_probe.py \
+            tools/test_motor_live_loss_probe.py \
+            tools/test_motor_live_loss_ros_smoke.py \
+            tools/test_physical_contract_probe.py \
+            tools/test_safe_cmd_vel_pulse.py
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hardware-free-checks-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            build/**/test_results/**
+            build/**/Testing/**
+            log/**
+            artifacts/ros-logs/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,17 @@ There are two separate contexts, and most contributions only need the first:
   python3 -m pytest -q tools/test_rosmaster_v339_pty.py
   ```
 
+  Every pull request runs this same build-and-test gate automatically (see
+  [`.github/workflows/hardware-free-checks.yml`](.github/workflows/hardware-free-checks.yml)),
+  minus `test_rosmaster_v339_pty.py` — CI never has `Rosmaster_Lib.py`
+  available, since it isn't vendored here for licensing reasons. CI also
+  skips vendoring `ros2_astra_camera` (`rosdep install --skip-keys
+  astra_camera`): it's `exec_depend`-only for `yahboomcar_astra`, and no
+  hardware-free test imports or launches it, so building the full camera SDK
+  on every run would cost time without adding coverage. Import it locally
+  with `vcs` as shown above if you actually need to build or run the camera
+  driver.
+
 - **Robot** — inside the robot's `rosmaster_humble` Docker container, cloned
   into `/root/yahboomcar_ws/src/physical_rosmaster`. See
   [Robot setup and manual bringup](README.md#robot-setup-and-manual-bringup) and


### PR DESCRIPTION
## Summary

Closes issue #9. Nothing in this repo runs automatically today — a broken build or a broken hardware-free test only surfaces when someone happens to run `colcon` locally. This wires up exactly the procedure `CONTRIBUTING.md` already documents by hand as a PR-triggered workflow on ROS 2 Humble, using the same container pattern already proven in `yahboom_rosmaster`'s CI (`ros:humble-ros-base-jammy`).

- `colcon build --symlink-install` + `colcon test` on all 8 packages, `colcon test-result --verbose` always printed, non-zero on any failing contract (pep257/copyright/flake8 gates plus the real logic tests like `test_x3_driver_feedback.py`, `test_sensor_adapter.py`, `test_scan_conversion.py`, `test_teleop_safety.py`).
- The standalone `tools/` pytest suite (`test_rosmaster_lib_probe`, `test_motor_live_loss_probe`, `test_motor_live_loss_ros_smoke`, `test_physical_contract_probe`, `test_safe_cmd_vel_pulse`).
- Failure diagnostics (build/test logs) uploaded as an artifact.

## Two intentional exclusions, both documented in CONTRIBUTING.md next to the commands they mirror

- **`ros2_astra_camera` is never vcs-imported/built.** It's `exec_depend`-only for `yahboomcar_astra` (checked `package.xml`), and no hardware-free test imports or launches it — `test_astra_launch.py` only inspects a `Node(package="astra_camera", ...)` action object in memory, which `launch_ros` never resolves against a real package. `rosdep install --skip-keys astra_camera` skips that one otherwise-unresolvable key (it's a pinned Orbbec fork, not a real rosdep/apt key) instead of vendoring the whole camera SDK on every run.
- **`tools/test_rosmaster_v339_pty.py` stays excluded**, matching the acceptance criterion that hardware/vendor-gated tests are clearly separated — it only runs against the real, unvendored `Rosmaster_Lib.py` via `ROSMASTER_V339_SOURCE`, which CI never has for licensing reasons.

## Verification

I don't have a way to run the actual GitHub Actions container here, so I could not execute this workflow end-to-end before opening the PR. What I did check:

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Every command in the workflow is a direct transcription of the exact commands `CONTRIBUTING.md` already documents and (per that doc) contributors already run locally, with only the two documented exclusions above.
- Confirmed `astra_camera`'s dependency type and traced every reference to it across the repo (package.xml, sensor_adapter.py, its test, the launch file) before deciding it's safe to skip in CI.

This PR's own new workflow will run on itself and is the real end-to-end confirmation — treat a green run as the actual validation, not this description.

## Test plan

- [ ] `Hardware-free checks` CI passes on this PR
- [ ] `colcon test-result` in the log shows all 8 packages tested, 0 failures
- [ ] The standalone `tools/` pytest step shows all 5 files collected and passing
