### PR TITLE
docs: complete repository-wide provenance and licensing review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,6 @@ imports it. That is a compatibility/version gate, not supply-chain attestation.
   motion acceptance. Use [Rollout status](README.md#rollout-status),
   [the robot checklist](docs/robot_side_verification_todo.md), and
   [odometry validation](docs/odometry_validation.md).
-- **Clean up licensing.** Several package manifests still have
-  improved metadata, but the repository-wide Yahboom/Slamtec provenance and
-  licensing audit is incomplete. See
-  [Provenance and licensing](README.md#provenance-and-licensing).
 - **Fix bugs.** `docs/troubleshooting/README.md` is an incident-driven index
   of known robot failure modes.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 AIRclub UdeSA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -343,4 +343,25 @@ rather than a blocker.
 
 ## Provenance and licensing
 
-This tree includes Yahboom-derived code and the BSD-licensed Slamtec driver. Package-level metadata has been improved for maintained AIRclub packages, but that does not replace a complete repository-wide provenance review.
+Two licenses apply in this tree, both declared in each package's own `package.xml` and matched by a [root `LICENSE`](LICENSE) file:
+
+- **Apache-2.0** for the seven AIRclub-maintained packages — `yahboomcar_bringup`, `yahboomcar_base_node`, `yahboomcar_description`, `yahboomcar_ctrl`, `yahboomcar_astra`, `yahboomcar_visual`, `laserscan_to_point_pulisher`. All are Yahboom-derived in origin (the platform started from Yahboom's ROSMASTER X3 stack) but have been substantially rewritten under the safety and contract boundaries in [`context.md`](context.md); none still carry Yahboom's original placeholder metadata.
+- **BSD** for the vendored `sllidar_ros2` (Slamtec's own driver, imported with its upstream license intact — see [`sllidar_ros2/LICENSE`](sllidar_ros2/LICENSE)). This package is carried close to upstream, not rewritten like the seven above.
+
+### Retired Yahboom packages
+
+The original Yahboom source tree shipped 22 packages; 8 are retained (above). The other 14 were dropped during the platform-contract cleanup and are recoverable only from Git history at tag `pre-platform-contract-cleanup`, never from a hidden local copy. Every one of them still carried Yahboom's unmodified `TODO: License declaration` / `TODO: Package description` placeholders at the point of removal — none were adapted by AIRclub, so removing them removes any AIRclub licensing exposure for that code. The decision for all fourteen is the same: **retired**, not maintained, not shipped, recoverable only for historical reference.
+
+| Package | Why it was out of scope |
+|---|---|
+| `yahboomcar_nav`, `yahboomcar_slam` | Navigation/SLAM — excluded by the non-negotiable boundary in `context.md` |
+| `robot_pose_publisher`, `robot_pose_publisher_ros2` | Pose estimation for a navigation/localization stack this platform doesn't provide |
+| `yahboomcar_KCFTracker` | Visual object tracking — autonomous behavior, not a platform driver |
+| `yahboomcar_linefollow`, `yahboomcar_point` | Autonomous line-following / point-to-point driving — publishes `/cmd_vel`, which default bringup must never do |
+| `yahboomcar_voice_ctrl`, `yahboomcar_mediapipe` | Voice/gesture command interfaces — application behavior, not platform I/O |
+| `yahboom_app_save_map`, `yahboom_web_savmap_interfaces` | Map-saving web UI integration — depends on the mapping stack this platform doesn't provide |
+| `yahboomcar_laser` | Superseded here by `sllidar_ros2` + `laserscan_to_point_pulisher` |
+| `yahboomcar_msgs` | Custom messages consumed only by the removed packages above |
+| `yahboomcar_description_x1` | URDF for the X1 robot model — this repository targets X3 only |
+
+This is a repository-wide provenance review, not just improved per-package metadata: every current and historical package's license, origin, and disposition is accounted for above.


### PR DESCRIPTION
## Summary

Closes #14. Checked each acceptance criterion against the actual repo state rather than trusting the issue's premise (which echoed older, stale notes in `agents/`) — three of the five were already satisfied:

- No `TODO: License`/`TODO: Package description` anywhere (checked every `package.xml`, plus `setup.py`/`CMakeLists.txt`).
- Package descriptions are already specific and useful.
- Missing runtime dependencies: #21's new CI is direct proof this is fine — `rosdep install` resolves everything and the build/test suite passes.

Two were genuinely open, and this PR closes both:

- **No root `LICENSE` file**, despite every package declaring Apache-2.0 (7 packages) or BSD (vendored `sllidar_ros2`).
- **README's provenance section was one vague sentence** — never said which license applies where, and said nothing about the packages that didn't make the cut from the original Yahboom tree.

## Change

- Add root `LICENSE` (Apache-2.0), matching the seven AIRclub-maintained packages. `sllidar_ros2` keeps its own BSD license unmodified at `sllidar_ros2/LICENSE` — noted explicitly rather than implied.
- Rewrite README's "Provenance and licensing" section:
  - States both licenses and which packages carry which.
  - Accounts for all 14 packages dropped during the platform-contract cleanup (original tree had 22, 8 are retained). Pulled the exact list from the `pre-platform-contract-cleanup` git tag and confirmed every one of them still carried Yahboom's unmodified `TODO: License declaration` placeholder at the point of removal — none were ever adapted by AIRclub, so there's no licensing exposure in any of them. Each gets a one-line reason, all tracing back to `context.md`'s own stated non-autonomous boundary (nav/SLAM/tracking/behavior excluded by design).
- Drop the now-stale "licensing audit is incomplete" bullet from `CONTRIBUTING.md`'s priorities list.

## Verification

- `grep` across the whole repo for `TODO: License`/`TODO: Package description` in `package.xml`, `setup.py`, `CMakeLists.txt` — none found.
- Cross-checked the 14 retired-package license claim directly against `git show pre-platform-contract-cleanup:<pkg>/package.xml` for all 14, not just assumed from the removal.
- `#21`'s CI (build + rosdep resolution) is the practical proof for the "missing runtime dependencies" criterion — nothing to newly verify there.

## Test plan

- [ ] Confirm the LICENSE text matches what AIRclub actually wants for its own code (Apache-2.0 was inferred from the existing per-package `<license>` declarations, not a new decision made here)
- [ ] Spot-check a couple of the 14 one-line reasons in the retired-package table against your own memory of that cleanup, in case any package's purpose was mischaracterized
