### PR TITLE
docs: replace stale pre-merge branch-pinning instructions with plain main

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ set -eo pipefail
 mkdir -p ~/rosmaster_physical_ws/src
 cd ~/rosmaster_physical_ws/src
 git clone https://github.com/AIRclub-UdeSA/physical_rosmaster.git
-# Current pre-merge x3-c recovery: select the reviewed platform branch using
-# physical_rosmaster/docs/robot_side_next_moves.md before importing dependencies.
 
 cd ~/rosmaster_physical_ws
 vcs import src < src/physical_rosmaster/physical_rosmaster.repos
@@ -133,12 +131,13 @@ must contain exactly the eight repository packages plus `astra_camera` and
 `astra_camera_msgs`. Do not replace the pin without repeating camera contract
 validation.
 
-The clone command above describes the eventual canonical setup from `main`.
-Until the simulator-parity work is merged, the current `x3-c` recovery must
-instead deploy one published `platform/simulator-parity` head whose exact full
-SHA has been reviewed and that contains both runtime commit `a08b097` and
-workstation-validation commit `bc965a6`; follow
-[the ordered recovery runbook](docs/robot_side_next_moves.md).
+The clone command above is the canonical setup from `main`, which merged the
+simulator-parity work (including runtime commit `a08b097` and
+workstation-validation commit `bc965a6`) on 2026-09-03. It supersedes the
+`platform/simulator-parity`-branch, SHA-pinned recovery procedure that
+[the ordered recovery runbook](docs/robot_side_next_moves.md) used to get
+`x3-c` through that merge; that runbook is now a historical record, not a
+setup path to repeat for another robot.
 
 Focused hardware-free checks:
 

--- a/docs/setup_guide_ros2_humble_autostart.md
+++ b/docs/setup_guide_ros2_humble_autostart.md
@@ -50,20 +50,16 @@ mkdir -p /root/yahboomcar_ws/src
 cd /root/yahboomcar_ws/src
 git clone https://github.com/AIRclub-UdeSA/physical_rosmaster.git
 
-# Current pre-merge x3-c recovery only: replace the marker with the reviewed
-# full SHA before running these checks.
 cd physical_rosmaster
 git fetch origin
-git checkout platform/simulator-parity
+git checkout main
 git pull --ff-only
 test -z "$(git status --porcelain)"
-test "$(git rev-parse HEAD)" = \
-  "$(git rev-parse origin/platform/simulator-parity)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 git merge-base --is-ancestor \
   a08b097b22781ca500fd61c01164a4e7167b3873 HEAD
 git merge-base --is-ancestor \
   bc965a6f5ccdafb01efd3a1a6a230e9d3bbd8e80 HEAD
-test "$(git rev-parse HEAD)" = "REPLACE_WITH_REVIEWED_FULL_SHA"
 
 cd ..
 vcs import . < physical_rosmaster/physical_rosmaster.repos
@@ -81,12 +77,13 @@ rosdep install --from-paths src --ignore-src -r -y
 The manifest pins `ros2_astra_camera`. Do not build an arbitrary current
 camera-driver branch.
 
-The default clone is the canonical new-robot path after this architecture is
-merged to `main`. Until then, do not deploy current `main` to `x3-c`; use
-[the ordered recovery runbook](robot_side_next_moves.md) to select one exact,
-published `platform/simulator-parity` head whose reviewed full SHA contains both
-runtime commit `a08b097` and workstation-validation commit `bc965a6` before
-importing dependencies or building.
+The default clone above is the canonical new-robot path: this architecture
+merged to `main` on 2026-09-03, and `main` contains both runtime commit
+`a08b097` and workstation-validation commit `bc965a6`. The
+`platform/simulator-parity`-branch, SHA-pinned procedure in
+[the ordered recovery runbook](robot_side_next_moves.md) was how `x3-c` got
+through that merge; it is a historical record, not a path to repeat for
+another robot.
 
 Verify the robot-provided motor library with the fail-closed preflight:
 

--- a/docs/workstation_and_robot_workflow.md
+++ b/docs/workstation_and_robot_workflow.md
@@ -17,8 +17,6 @@ set -eo pipefail
 mkdir -p ~/rosmaster_physical_ws/src
 cd ~/rosmaster_physical_ws/src
 git clone https://github.com/AIRclub-UdeSA/physical_rosmaster.git
-# Current pre-merge x3-c rollout: select the reviewed platform branch using
-# physical_rosmaster/docs/robot_side_next_moves.md before importing dependencies.
 
 cd ~/rosmaster_physical_ws
 vcs import src < src/physical_rosmaster/physical_rosmaster.repos
@@ -32,11 +30,12 @@ colcon build --symlink-install
 )
 ```
 
-This default clone is the canonical workflow after the architecture reaches
-`main`. For the current pre-merge `x3-c` rollout, select one reviewed,
-published `platform/simulator-parity` head at an exact reviewed full SHA that
-contains both `a08b097` and `bc965a6` before the `vcs import`; use
-[robot_side_next_moves.md](robot_side_next_moves.md).
+This default clone is the canonical workflow: the architecture reached `main`
+on 2026-09-03, and `main` contains both `a08b097` and `bc965a6`. The
+`platform/simulator-parity`-branch, SHA-pinned procedure in
+[robot_side_next_moves.md](robot_side_next_moves.md) was how `x3-c` got
+through that merge; it is a historical record, not a step to repeat for
+another robot.
 
 Expected local package inventory:
 
@@ -116,8 +115,8 @@ Expected paths:
 
 Before changing an existing workspace, put source backups outside `/root/yahboomcar_ws`. A backup containing packages anywhere under the workspace causes duplicate package discovery.
 
-For the current pre-merge `x3-c` rollout, replace the reviewed-SHA marker and
-verify the exact published revision before importing or building:
+Before importing or building, verify the checkout is clean, on `main`, and
+matches the remote:
 
 ```bash
 (
@@ -125,16 +124,14 @@ set -eo pipefail
 
 cd /root/yahboomcar_ws/src/physical_rosmaster
 git fetch origin
-git checkout platform/simulator-parity
+git checkout main
 git pull --ff-only
 test -z "$(git status --porcelain)"
-test "$(git rev-parse HEAD)" = \
-  "$(git rev-parse origin/platform/simulator-parity)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 git merge-base --is-ancestor \
   a08b097b22781ca500fd61c01164a4e7167b3873 HEAD
 git merge-base --is-ancestor \
   bc965a6f5ccdafb01efd3a1a6a230e9d3bbd8e80 HEAD
-test "$(git rev-parse HEAD)" = "REPLACE_WITH_REVIEWED_FULL_SHA"
 )
 ```
 


### PR DESCRIPTION
## Summary

Found while checking whether this repo's setup docs are actually fast/accurate for onboarding another fleet robot: `README.md`, `docs/setup_guide_ros2_humble_autostart.md`, and `docs/workstation_and_robot_workflow.md` all still instruct `git checkout platform/simulator-parity` at a `REPLACE_WITH_REVIEWED_FULL_SHA` placeholder, framed as a "pre-merge x3-c" workaround. That branch merged to `main` on 2026-09-03 (#3). Following these docs today for a new robot means doing unnecessary branch-pinning gymnastics instead of a plain clone + `main`, which is what's actually correct now.

## Change

In all three files: check out `main` instead of `platform/simulator-parity`, drop the `REPLACE_WITH_REVIEWED_FULL_SHA` placeholder, and keep the `a08b097`/`bc965a6` ancestry checks (still a real sanity check, just against `main`). Reworded the surrounding prose to state plainly that `main` is canonical now, and that `robot_side_next_moves.md` (and `robot_side_verification_todo.md`, referenced from it) is a historical record of how `x3-c` got through that merge — not left untouched by accident, but deliberately: it's an `x3-c`-specific point-in-time checklist, not a doc meant to be rewritten for future robots.

## Verification

Read the full text around every edit to confirm nothing else in these sections still assumed the pre-merge state, and grepped the three files afterward for `platform/simulator-parity`/`pre-merge`/`REPLACE_WITH_REVIEWED_FULL_SHA` — the only remaining hits are the new sentences explicitly describing that branch in the past tense.
