### PR TITLE
docs: rewrite the setup guide as a fast per-robot path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,10 @@ There are two separate contexts, and most contributions only need the first:
 - **Robot** — inside the robot's `rosmaster_humble` Docker container, cloned
   into `/root/yahboomcar_ws/src/physical_rosmaster`. See
   [Robot setup and manual bringup](README.md#robot-setup-and-manual-bringup) and
-  [the setup and autostart gate](docs/setup_guide_ros2_humble_autostart.md) for
-  the clone, build, and manual-validation procedure. Back up the existing
-  `src` tree before replacing a robot workspace. Autostart is not authorized.
+  [the setup guide](docs/setup_guide_ros2_humble_autostart.md) for the clone,
+  build, and per-robot hardware procedure. Back up the existing `src` tree
+  before replacing a robot workspace. Autostart is accepted for this stack;
+  see [docs/autostart_setup.md](docs/autostart_setup.md).
 
 `Rosmaster_Lib` is not vendored here — on the robot it's copied in from the
 Yahboom host installation. Its allowlisted source hash is checked after Python
@@ -81,10 +82,13 @@ imports it. That is a compatibility/version gate, not supply-chain attestation.
 
 ## Current priorities
 
-- **Close validation gates.** Runtime commit `a08b097` still needs clean robot
-  deployment, the positive/startup-absence/restoration/live-loss/restoration
-  sequence, bounded active-stop validation, and then supervised lifted/floor
-  motion acceptance. Use [Rollout status](README.md#rollout-status),
+- **Close the remaining validation gates.** `x3-c` already passed the core
+  robot deployment, startup-absence/restoration/live-loss sequence, and a
+  qualitative floor pass; autostart is separately installed and
+  reboot-validated. Still open: the full 3-rep measured floor protocol with
+  external measurement, operator-tool (joystick/keyboard/calibration) checks,
+  and a simulator/physical consumer-parity proof. Use
+  [Rollout status](README.md#rollout-status),
   [the robot checklist](docs/robot_side_verification_todo.md), and
   [odometry validation](docs/odometry_validation.md).
 - **Fix bugs.** `docs/troubleshooting/README.md` is an incident-driven index

--- a/README.md
+++ b/README.md
@@ -193,54 +193,26 @@ The expected clone path is `/root/yahboomcar_ws/src/physical_rosmaster` in the
 dependency and is not vendored here. Its source hash verifies the reviewed
 runtime shape after import; it does not establish package provenance or trust.
 
-Before constructing the driver, run the fail-closed installed-source preflight
-from the repository root:
+For bringing up an X3 that isn't `x3-c` — clone/build, identify this unit's
+hardware, and one smoke check that it's wired right — follow
+[docs/setup_guide_ros2_humble_autostart.md](docs/setup_guide_ros2_humble_autostart.md).
+It's deliberately fast: the platform code itself is already validated, so it
+doesn't re-run the one-time protocol/safety proofs `x3-c` went through.
 
-```bash
-cd /root/yahboomcar_ws/src/physical_rosmaster
-python3 tools/rosmaster_lib_probe.py --hash-only
-```
-
-Continue only if it exits `0` and reports the supported V3.3.9 digest. A
-nonzero result is a deployment blocker; do not substitute visual comparison of
-hash output.
-
-Discover and configure stable hardware identities before launch:
+In short, once cloned and built:
 
 ```bash
 source /opt/ros/humble/setup.bash
 source /root/yahboomcar_ws/install/setup.bash
-ls -l /dev/serial/by-id
-lsusb
-ros2 run astra_camera list_devices_node
-```
-
-Set per-robot identities in the container environment:
-
-```bash
 export ROSMASTER_MOTOR_PORT="/dev/serial/by-id/REPLACE_WITH_MOTOR_CONTROLLER_ID"
 export ROSMASTER_LIDAR_PORT=/dev/robot/lidar
 export ROSMASTER_ASTRA_SERIAL="REPLACE_WITH_ASTRA_SERIAL"
-```
 
-Before launch, stop every competing legacy/controller process, verify that no
-command source or `/cmd_vel` publisher remains, and secure or lift all four
-wheels. Then launch manually:
-
-```bash
 cd /root/yahboomcar_ws
-source /opt/ros/humble/setup.bash
-source install/setup.bash
 ros2 launch yahboomcar_bringup yahboomcar_bringup_X3_launch.py
 ```
 
-Normal bringup shuts down when a required process exits. The motor driver
-fails terminally on missing/stale required report channels, receiver failure,
-or an observed serial-write failure. The camera adapter fails if all valid
-RGB-D streams do not appear within its startup deadline. The physical probe
-requires current healthy controller and encoder `/diagnostics` before passing.
-
-In a second shell, run the contract gate:
+Then, in a second shell, confirm it came up healthy:
 
 ```bash
 source /opt/ros/humble/setup.bash
@@ -249,27 +221,10 @@ cd /root/yahboomcar_ws/src/physical_rosmaster
 python3 tools/physical_contract_probe.py
 ```
 
-After the positive contract, test motor absence at startup. Stop bringup,
-disconnect only the motor controller, relaunch, and require the driver never to
-become healthy and the strict graph to drain. Reconnect it, start a clean
-launch, and pass the complete physical contract again before the subsequent
-supervised no-motion live-loss gate.
-
-For live loss, export the same motor path in the probe shell, create the
-evidence directory, and pass both explicitly:
-
-```bash
-export ROSMASTER_MOTOR_PORT="/dev/serial/by-id/REPLACE_WITH_MOTOR_CONTROLLER_ID"
-mkdir -p /root/rosmaster-recovery-evidence
-python3 tools/motor_live_loss_probe.py \
-  --device "$ROSMASTER_MOTOR_PORT" \
-  --confirm-wheels-secured \
-  --output /root/rosmaster-recovery-evidence/motor-live-loss.json
-```
-
-Follow [the workstation/robot workflow](docs/workstation_and_robot_workflow.md)
-for the `ARMED`, second restoration, and final positive-contract sequence.
-This probe is not an active-motion stop test.
+Normal bringup shuts down when a required process exits — the motor driver on
+missing/stale report channels, receiver failure, or a serial-write failure;
+the camera adapter if RGB-D streams don't appear within its startup deadline.
+The physical probe requires healthy controller and encoder `/diagnostics`.
 
 ## Operator tools
 
@@ -294,7 +249,7 @@ Manual control is capped at `0.20 m/s` linear and `1.0 rad/s` angular, with lowe
 
 ## Rollout status
 
-Autostart remains blocked. Runtime commit `a08b097` and the robot-validation
+Runtime commit `a08b097` and the robot-validation
 tooling hardened by `bc965a6` passed full robot deployment and validation on
 `x3-c` on 2026-09-02, at exact reviewed head `e34f8a3`.
 
@@ -322,8 +277,10 @@ The gate is:
    calibration) checks remain open;
 5. run one minimal consumer against simulator and hardware without remaps.
 
-Item 4's full measured protocol, operator tools, and item 5 remain open. Once
-they pass, a new autostart routine may be designed. Lifted-motion diagnosis
+Item 4's full measured protocol, operator tools, and item 5 remain open.
+Autostart itself is no longer gated on them, though: it has already been
+designed, installed, enabled, and reboot-validated on `x3-c` — see
+[docs/autostart_setup.md](docs/autostart_setup.md). Lifted-motion diagnosis
 also found a repeatable ~2-4x front-right-vs-back-left actuation imbalance,
 most pronounced below roughly `0.10 m/s`/`0.60 rad/s` per-wheel-equivalent;
 the owner is tracking this as an accepted known platform characteristic (see
@@ -332,7 +289,7 @@ rather than a blocker.
 
 ## Documentation
 
-- [docs/setup_guide_ros2_humble_autostart.md](docs/setup_guide_ros2_humble_autostart.md): manual robot setup and the explicit autostart gate;
+- [docs/setup_guide_ros2_humble_autostart.md](docs/setup_guide_ros2_humble_autostart.md): fast setup for an additional fleet robot;
 - [docs/workstation_and_robot_workflow.md](docs/workstation_and_robot_workflow.md): workstation/robot responsibilities;
 - [docs/robot_side_verification_todo.md](docs/robot_side_verification_todo.md): mandatory first-robot verification checklist and evidence record;
 - [docs/robot_side_next_moves.md](docs/robot_side_next_moves.md): ordered `x3-c` remediation and acceptance runbook;

--- a/context.md
+++ b/context.md
@@ -12,8 +12,12 @@ External projects own all behavior and run on top of the same public topics and 
 
 - validated pre-cleanup baseline: `aafed44`;
 - recovery tag: `pre-platform-contract-cleanup`;
-- implementation branch: `platform/simulator-parity`;
-- autostart: blocked until robot-side acceptance.
+- `platform/simulator-parity` merged to `main` 2026-09-03 (PR #3); `main` is
+  the implementation state now;
+- autostart: accepted and enabled on `x3-c`. Additional robots follow
+  [docs/setup_guide_ros2_humble_autostart.md](docs/setup_guide_ros2_humble_autostart.md)
+  then [docs/autostart_setup.md](docs/autostart_setup.md) directly — no
+  separate per-robot acceptance gate.
 
 ## Runtime graph
 
@@ -52,17 +56,20 @@ python3 tools/physical_contract_probe.py
 
 The physical probe requires all public sensor topics, unique sensor/odometry publishers, healthy controller and encoder diagnostics, finite and increasing data, valid calibration, metric depth, XYZRGB fields, correct frames, odometry TF ownership, and time-resolvable `odom` → sensor transforms. It also verifies that default bringup has no `/cmd_vel` publisher.
 
-## Hardware gate still outstanding
+## Hardware gate: done for the platform, not per-robot
 
-Workstation validation cannot establish the camera model/serial, USB/udev state, encoder signs on another unit, sensor calibration validity, or floor behavior. On one X3:
+`x3-c` completed the one-time platform gate (workstation validation cannot
+establish camera model/serial, USB/udev state, encoder signs, sensor
+calibration, or floor behavior, so all of that had to happen on real
+hardware): import, hardware identity, manual strict bringup and the
+non-motion probe, lifted and floor tests, and a consumer comparison against
+the simulator without remaps. That proved the *code*; it does not need
+repeating for each additional robot in the fleet.
 
-1. import `physical_rosmaster.repos` and install dependencies with `rosdep`;
-2. identify motor, A1, and Astra stable identities;
-3. run manual strict bringup and the non-motion probe;
-4. run lifted and bounded floor tests from the current docs;
-5. compare one consumer against the simulator without remaps.
-
-Do not prepare or enable a new autostart routine before that gate passes.
+For another X3 running the same accepted `main` code, follow
+[docs/setup_guide_ros2_humble_autostart.md](docs/setup_guide_ros2_humble_autostart.md):
+clone/build, identify that unit's hardware, and one smoke check that it's
+wired correctly — fast, and deliberately not a repeat of the above.
 
 ## Historical evidence
 

--- a/docs/autostart_setup.md
+++ b/docs/autostart_setup.md
@@ -1,11 +1,14 @@
 # Autostart install and validation
 
-Installs the versioned systemd autostart described in
-[setup_guide_ros2_humble_autostart.md](setup_guide_ros2_humble_autostart.md)'s
-"Autostart decision" section. Do this only after the robot has passed the
+Installs the versioned systemd autostart. Autostart is already validated for
+this platform code — `x3-c` passed the
 [robot-side verification checklist](robot_side_verification_todo.md) sections
-1-6. Run every command on the robot's host, not inside the container, unless
-shown otherwise.
+1-6 before this was first installed there, but that checklist is
+`x3-c`-specific history, not a precondition for another robot. For any other
+X3, do this once
+[setup_guide_ros2_humble_autostart.md](setup_guide_ros2_humble_autostart.md)'s
+smoke check passes. Run every command on the robot's host, not inside the
+container, unless shown otherwise.
 
 ## 1. File layout
 
@@ -30,7 +33,7 @@ rules template works.
 
 ## 2. Discover per-robot values
 
-Follow [setup_guide_ros2_humble_autostart.md section 4](setup_guide_ros2_humble_autostart.md#4-identify-required-hardware)
+Follow [setup_guide_ros2_humble_autostart.md section 3](setup_guide_ros2_humble_autostart.md#3-identify-this-robots-hardware)
 to record the motor, LiDAR, and Astra identities for this robot. You need:
 
 - the motor serial path (prefer `/dev/serial/by-id/...`; fall back to the

--- a/docs/setup_guide_ros2_humble_autostart.md
+++ b/docs/setup_guide_ros2_humble_autostart.md
@@ -1,21 +1,30 @@
-# ROS 2 Humble X3 setup and autostart gate
+# ROS 2 Humble X3 setup
 
 Despite the historical filename, this document does not install or enable
-autostart. The old routine targeted the former EKF/application tree and
-unstable `/dev/ttyUSB*`/`/dev/video*` names. It must not be reused.
+autostart — see [autostart_setup.md](autostart_setup.md) for that, once this
+guide's checks pass. The old routine targeted the former EKF/application tree
+and unstable `/dev/ttyUSB*`/`/dev/video*` names. It must not be reused.
 
-This guide prepares one robot for manual validation. Autostart remains blocked
-until the final gate passes.
+This is the fast path for bringing up an *additional* X3 running the
+already-accepted `main` platform code. It covers only what's genuinely
+per-robot: cloning and building, identifying this unit's hardware, and one
+smoke check that it's wired correctly. It deliberately does **not** repeat the
+one-time platform validation that `x3-c` already went through — the motor
+live-loss protocol proof, the active-link-loss characteristic, and the
+simulator/physical consumer-parity proof all test the *code*, not the unit,
+and don't need re-running per robot. See
+[robot_side_verification_todo.md](robot_side_verification_todo.md) and
+[robot_side_next_moves.md](robot_side_next_moves.md) if you want that history;
+neither is required reading to bring up a new robot.
 
 ## 1. Preconditions
 
 - Yahboom ROS 2 Humble container is operational.
-- The robot is an ROSMASTER X3; X1 and R2 are unsupported.
+- The robot is a ROSMASTER X3; X1 and R2 are unsupported.
 - The host exposes motor controller, A1 LiDAR, and Astra USB devices to the
   container.
 - Existing source and generated-state backups are outside
   `/root/yahboomcar_ws`.
-- Host autostart is disabled while validation is in progress.
 - The `vcs` command is available in the container (`python3-vcstool` on
   Ubuntu).
 
@@ -35,10 +44,8 @@ active container or image can consume most of the disk while Docker reports no
 reclaimable space, and `docker system prune -a` does not shrink an active
 container's writable layer. Diagnose the actual consumer first; see
 [Root filesystem full causing LightDM login loop and Docker growth](troubleshooting/known_issues/root-filesystem-full-login-loop.md).
-Preserve bags, calibration, and acceptance evidence, and never delete
-`/var/lib/docker` manually.
 
-## 2. Source and dependencies
+## 2. Clone and build
 
 Inside the container:
 
@@ -56,10 +63,6 @@ git checkout main
 git pull --ff-only
 test -z "$(git status --porcelain)"
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-git merge-base --is-ancestor \
-  a08b097b22781ca500fd61c01164a4e7167b3873 HEAD
-git merge-base --is-ancestor \
-  bc965a6f5ccdafb01efd3a1a6a230e9d3bbd8e80 HEAD
 
 cd ..
 vcs import . < physical_rosmaster/physical_rosmaster.repos
@@ -71,19 +74,14 @@ cd /root/yahboomcar_ws
 source /opt/ros/humble/setup.bash
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y
+colcon build --symlink-install
+source install/setup.bash
 )
 ```
 
-The manifest pins `ros2_astra_camera`. Do not build an arbitrary current
-camera-driver branch.
-
-The default clone above is the canonical new-robot path: this architecture
-merged to `main` on 2026-09-03, and `main` contains both runtime commit
-`a08b097` and workstation-validation commit `bc965a6`. The
-`platform/simulator-parity`-branch, SHA-pinned procedure in
-[the ordered recovery runbook](robot_side_next_moves.md) was how `x3-c` got
-through that merge; it is a historical record, not a path to repeat for
-another robot.
+The manifest pins `ros2_astra_camera`; don't build an arbitrary current
+camera-driver branch. The workspace inventory should show exactly eight local
+packages plus `astra_camera` and `astra_camera_msgs`.
 
 Verify the robot-provided motor library with the fail-closed preflight:
 
@@ -92,74 +90,16 @@ cd /root/yahboomcar_ws/src/physical_rosmaster
 python3 tools/rosmaster_lib_probe.py --hash-only
 ```
 
-The command must exit `0` and report the supported V3.3.9 digest. If it returns
-nonzero or cannot import the library, stop and restore the Yahboom
-host/container integration before building. Do not vendor an unknown
-`Rosmaster_Lib` copy into this repository or accept a mismatch by visually
-comparing printed output.
+The command must exit `0` and report the supported V3.3.9 digest. If it
+returns nonzero or can't import the library, stop and restore the Yahboom
+host/container integration before continuing — don't vendor an unknown
+`Rosmaster_Lib` copy into this repository, and don't accept a mismatch by
+eyeballing printed output. The only supported SHA256 is
+`e9fd0f6bb015cda7dba58f4db6994402d83865cc125ab33035dbb39e978b1a8c`; the driver
+checks this itself at runtime too, so this is an early, cheap version of the
+same check.
 
-The only supported `Rosmaster_Lib.py` SHA256 is
-`e9fd0f6bb015cda7dba58f4db6994402d83865cc125ab33035dbb39e978b1a8c`.
-Runtime commit `a08b097` checks this digest after importing the library and
-refuses to construct the controller transport when it differs. This is a
-compatibility/version gate for the exact implementation whose private receive
-and parse hooks were reviewed. It is not supply-chain attestation: matching
-bytes do not establish who delivered the file, whether its installation path
-is trusted, or whether the surrounding system is uncompromised. Commit
-`bc965a6` makes the standalone preflight return nonzero for an unsupported
-source.
-
-After the vendor constructor returns, `a08b097` applies and verifies a `0.05 s`
-pyserial `write_timeout`, then wraps runtime writes so exceptions and short
-writes become terminal driver failures. The V3.3.9 constructor's UART-servo
-torque-enable write occurs before that wrapper is installed. A completed
-runtime host write also proves only that the serial layer accepted the frame;
-it is not an acknowledgement that the motor controller executed it or that the
-robot physically stopped.
-
-## 3. Build from clean generated state
-
-```bash
-(
-set -eo pipefail
-
-cd /root/yahboomcar_ws
-
-# Moving these trees outside the workspace is recoverable and prevents stale
-# generated state reuse.
-archive_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-generated_archive="/root/rosmaster-workspace-archives/${archive_stamp}-pre-deploy"
-test ! -e "$generated_archive"
-mkdir -p /root/rosmaster-workspace-archives
-mkdir "$generated_archive"
-for generated_tree in build install log; do
-  if [ -e "$generated_tree" ]; then
-    mv -- "$generated_tree" "$generated_archive/"
-  fi
-done
-test ! -e build
-test ! -e install
-test ! -e log
-
-colcon list --base-paths src
-colcon build --symlink-install
-colcon test --packages-select \
-  laserscan_to_point_pulisher sllidar_ros2 yahboomcar_astra \
-  yahboomcar_base_node yahboomcar_bringup yahboomcar_ctrl \
-  yahboomcar_description yahboomcar_visual
-colcon test-result --verbose
-source install/setup.bash
-)
-```
-
-Keep the archived generated state until the clean build and test evidence has
-been reviewed; remove it later only as a separate, explicit maintenance action.
-
-The workspace inventory must show exactly eight local packages plus
-`astra_camera` and `astra_camera_msgs`. The external camera-driver worktree must
-be clean and remain at the commit pinned in `physical_rosmaster.repos`.
-
-## 4. Identify required hardware
+## 3. Identify this robot's hardware
 
 On the host:
 
@@ -177,35 +117,22 @@ source /root/yahboomcar_ws/install/setup.bash
 ros2 run astra_camera list_devices_node
 ```
 
-Record exact model, vendor/product IDs, and stable identity for:
-
-- motor controller;
-- Slamtec A1 serial adapter;
-- Astra-family RGB-D camera.
-
-For `x3-c`, the accepted camera topology is the powered Yahboom hub,
-downstream port 4. In that topology, one cold boot followed by three consecutive
-warm boots enumerated both Astra USB functions, `2bc5:060f` for depth and
-`2bc5:050f` for UVC/RGB, without touching or reconnecting any cable. Preserve
-that topology for `x3-c`. This is evidence for that robot, hub, power path, and
-cable; it is not a universal instruction that every X3 must use port 4. Record
-and boot-validate the stable topology of each additional robot independently.
-
-If no Orbbec/Astra device appears, strict simulator parity fails. Stop here; do
-not prepare autostart.
+Record exact model, vendor/product IDs, and stable identity for the motor
+controller, the Slamtec A1 serial adapter, and the Astra-family RGB-D camera.
+This is unavoidably per-robot: USB topology, cable routing, and which hub port
+things land on vary unit to unit. If no Orbbec/Astra device appears, stop here
+and fix the physical connection before continuing.
 
 Use [../config/99-rosmaster-x3.rules.example](../config/99-rosmaster-x3.rules.example)
-as a template. Replace placeholders with observed values, install it on the
-host, reload udev rules, reconnect the devices, and verify the final aliases. A
-literal placeholder rule is intentionally nonfunctional.
+as a template. Replace placeholders with this robot's observed values, install
+it on the host, reload udev rules, reconnect the devices, and verify the final
+aliases. Some CH340 motor controllers expose no serial; for those, bind
+`/dev/robot/motor` to a dedicated physical USB port using the documented
+`KERNELS` fallback and verify that identity survives a reboot.
 
-Prefer a unique device serial. Some CH340 motor controllers expose no serial;
-for those units, bind `/dev/robot/motor` to a dedicated physical USB port using
-the documented `KERNELS` fallback and verify that identity after reboot.
+## 4. Configure identities
 
-## 5. Configure identities
-
-In the container shell used for manual launch:
+In the container shell used for launch:
 
 ```bash
 export ROSMASTER_MOTOR_PORT="/dev/serial/by-id/REPLACE_WITH_MOTOR_CONTROLLER_ID"
@@ -213,13 +140,12 @@ export ROSMASTER_LIDAR_PORT=/dev/robot/lidar
 export ROSMASTER_ASTRA_SERIAL="REPLACE_WITH_ASTRA_SERIAL"
 ```
 
-The camera serial may be temporarily omitted only during discovery with exactly
-one device attached. It must be recorded and selected before acceptance.
+## 5. Smoke-check the launch
 
-## 6. Manual non-motion gate
-
-Lift the drive wheels or otherwise prevent unintended movement. Start only
-default bringup:
+This is the one check worth running before calling a new robot done: confirm
+the platform actually comes up healthy on *this* unit's wiring. It's not a
+re-proof of the driver — that's already established — just a fast sanity
+check that nothing's plugged in wrong. Lift the drive wheels, then:
 
 ```bash
 cd /root/yahboomcar_ws
@@ -228,7 +154,7 @@ source install/setup.bash
 ros2 launch yahboomcar_bringup yahboomcar_bringup_X3_launch.py
 ```
 
-Do not start any command publisher. In another shell:
+In another shell:
 
 ```bash
 source /opt/ros/humble/setup.bash
@@ -237,149 +163,19 @@ cd /root/yahboomcar_ws/src/physical_rosmaster
 python3 tools/physical_contract_probe.py
 ```
 
-Acceptance requires:
+If it doesn't pass on the first try, the probe's output says exactly what's
+missing or wrong — usually a device path, a loose connector, or a camera
+serial that doesn't match what's plugged in, not a code problem.
 
-- exactly one publisher for every sensor topic, `/joint_states`, and `/odom`;
-- no `/cmd_vel` publisher;
-- increasing timestamps and finite data;
-- `rgb8` color and calibrated intrinsics;
-- `32FC1` metric depth with plausible samples;
-- XYZRGB cloud in `cam_1_depth_frame`;
-- scan in `laser_link` and IMU in `imu_link`;
-- canonical wheel joints;
-- observed `odom -> base_footprint` authority from wheel odometry;
-- healthy controller/encoder status on `/diagnostics`;
-- `odom` to every sensor frame resolvable at message time.
+Optionally, with wheels still lifted, use the bounded pulse tool
+(`tools/safe_cmd_vel_pulse.py`) to confirm forward/strafe/rotation move the
+wheels in the expected direction and `/odom` agrees — this checks *this
+unit's* encoder and motor wiring, not the driver, and takes under a minute.
+See [odometry_validation.md](odometry_validation.md) if anything looks
+backwards.
 
-Required driver exit or camera startup failure must stop bringup. Fix
-hardware/dependencies rather than making sensors optional.
+## 6. Install autostart
 
-### Required devices absent at startup
-
-On every new X3, test the camera, LiDAR, and motor controller separately. Keep
-the wheels secured and start strict bringup with exactly one required device
-absent. Camera and LiDAR failure must stop strict bringup; with the motor absent,
-the driver must never become healthy, must exit after the startup-feedback
-deadline, and the strict graph must drain. After each test, restore the device,
-restart from a clean launch, and pass the full physical contract before
-continuing.
-
-For the current motor-only `x3-c` remediation, the previously accepted camera
-and LiDAR startup-absence results may be carried forward unless deployment or
-positive-contract evidence regresses. Motor startup absence and its restored
-full contract must be repeated before the live-loss test.
-
-### Observer-only live motor-controller loss
-
-The exact reviewed head containing `a08b097` and `bc965a6` is still pending
-this robot-side validation. Keep the wheels secured and do not start joystick,
-keyboard, calibration, or any other command source. After strict bringup passes
-its full baseline, run from the repository root:
-
-```bash
-export ROSMASTER_MOTOR_PORT="/dev/serial/by-id/REPLACE_WITH_MOTOR_CONTROLLER_ID"
-mkdir -p /root/rosmaster-recovery-evidence
-python3 tools/motor_live_loss_probe.py \
-  --device "$ROSMASTER_MOTOR_PORT" \
-  --confirm-wheels-secured \
-  --output /root/rosmaster-recovery-evidence/motor-live-loss.json
-```
-
-Acceptance requires all of the following in the probe result:
-
-- a complete, fresh, stationary baseline for every controller-derived topic;
-- no `/cmd_vel` publisher and no `/cmd_vel` message before or after loss;
-- controller-derived topics become quiet after the motor device disappears;
-- motor diagnostics reach `ERROR` with structured failed freshness evidence;
-- `driver_node` exits;
-- the strict ROS graph drains and remains stably drained for the probe's
-  observation window; and
-- after restoring the controller, a clean strict launch passes the full
-  physical contract again.
-
-This observer-only, no-command test proves ROS data, diagnostic, process-exit,
-and graph-drain behavior. It does **not** prove that a robot already moving will
-physically stop when feedback or the serial link is lost.
-
-## 7. Lifted and floor motion gates
-
-Follow [odometry_validation.md](odometry_validation.md). Use only the bounded
-pulse, joystick, or keyboard tool under direct supervision, one publisher at a
-time.
-
-Verify:
-
-- forward, left-strafe, and CCW encoder signs;
-- `/odom` direction and TF;
-- command watchdog stop;
-- joystick held deadman, release stop, malformed-input protection, and timeout;
-- keyboard timeout;
-- calibration remains inert unless explicitly activated.
-
-After the observer-only live-loss gate passes, perform a separate active safety
-gate with all four wheels securely lifted, the main power switch immediately
-reachable, an observer present, and only one very-low-speed command source.
-First prove the software command watchdog produces a bounded physical stop when
-the command stream ends while the link remains healthy. Then, under the same
-restrained conditions, test active controller-link loss against a
-predeclared stop-time bound and record command, wheel motion, diagnostics, and
-power intervention. Cut the main switch immediately if behavior is unexpected
-or the bound is exceeded.
-
-Host write completion is not controller execution acknowledgement. Tested on
-`x3-c` on 2026-09-02: the lifted active-link-loss test did not demonstrate a
-bounded physical stop (wheels kept turning, actively driven, for at least 28
-seconds until main power was cut). This was root-caused to a protocol-level
-absence of any command-loss watchdog in the motor controller — see
-[the known-issue writeup](troubleshooting/known_issues/motor-controller-no-link-loss-watchdog.md).
-The project owner accepted this as a known platform limitation rather than a
-blocking requirement, so it no longer prevents floor use. Main power remains
-the only proven stop mechanism for a command-link loss during motion. Do not
-treat repeated host zero writes as a substitute.
-
-Then repeat conservative floor trials with external observations. Do not tune
-geometry or covariance from visual impression alone.
-
-## 8. Simulator/physical acceptance
-
-Run the same minimal consumer or contract-facing project against:
-
-1. simulator commit `772ba25`;
-2. this physical platform.
-
-No topic remaps or frame-name substitutions are allowed. Simulation-only clock
-and ground truth are excluded.
-
-## 9. Autostart decision
-
-Autostart work may begin only when one X3 has passed:
-
-- full non-motion probe;
-- camera-, LiDAR-, and motor-absent startup gates with a restored full contract
-  after each (subject only to the documented current `x3-c` exception);
-- observer-only motor live-loss and its restored full contract;
-- lifted motion and safety gates (the active-link-loss physical-stop trial is
-  a documented, owner-accepted exception rather than a required pass — see
-  [the known-issue writeup](troubleshooting/known_issues/motor-controller-no-link-loss-watchdog.md));
-- bounded floor gates;
-- simulator/physical consumer acceptance;
-- stable motor, LiDAR, and camera identity configuration.
-
-The future routine should be versioned in this repository, invoke the single
-strict platform launch, load per-robot identity configuration, propagate
-failures to the host service, and never start joystick, keyboard, calibration,
-or project behavior by default. It should also:
-
-- refuse startup when the root filesystem is at least 95% used or has less than
-  2 GiB free;
-- cap persistent journald storage and Docker container logs;
-- keep cleanup in a separate maintenance timer rather than ROS bringup;
-- preserve bags, calibration, and acceptance evidence; and
-- keep bringup in the foreground so failures propagate to the service manager.
-
-Test a future disk guard by temporarily raising its threshold, never by filling
-the robot's storage.
-
-The exact reviewed head containing `a08b097` and `bc965a6` remains pending these
-robot-side gates. Until they all pass, leave the fleet autostart disabled for
-this new stack.
+Autostart is already validated for this stack — follow
+[autostart_setup.md](autostart_setup.md) directly, no separate decision gate
+needed.


### PR DESCRIPTION
**Stacked on #23** — this PR's diff includes that commit until #23 merges; the actual new work here is just the second commit.

## Summary

Direct follow-up to #24: the project owner decided the setup guide should stop re-running x3-c's one-time acceptance gate for every new fleet robot, since the *code* is already proven. This does that rewrite.

`docs/setup_guide_ros2_humble_autostart.md` walked through x3-c's entire acceptance sequence as if it needed repeating per robot: per-device startup-absence tests, the evidence-collecting motor live-loss probe, the lifted active-link-loss stopwatch trial (already a documented, owner-accepted platform limitation — not something to re-discover per unit), and a simulator/physical consumer-parity proof. All of that establishes facts about the *code*, not about a specific unit's wiring, so redoing it per robot is hours of redundant work.

## Change

- **`docs/setup_guide_ros2_humble_autostart.md`**: cut down to what's actually per-robot — clone/build, hardware identity discovery + udev rules, and one smoke check (launch + a single `physical_contract_probe.py` pass, plus an optional under-a-minute direction/encoder sanity check with the bounded pulse tool, since `context.md` already documents that encoder signs and floor behavior can't be established from the workstation and do vary per unit). Ends with a direct pointer to `autostart_setup.md` instead of the old "autostart decision" checklist, which no longer applies to a new robot running already-accepted code.
- **`README.md`**: "Robot setup and manual bringup" now points at the setup guide instead of duplicating (and including) the full gate.
- **Fixed real staleness this surfaced** (verified, not assumed):
  - README's "Rollout status" still opened with "Autostart remains blocked" and closed with "a new autostart routine may be designed" — both false since 2026-09-01, confirmed against `docs/robot_side_verification_todo.md`'s own already-corrected framing ("autostart was designed, installed, and reboot-validated... Section 7 (simulator/physical consumer parity) remains open"). Left items 4/5 exactly as "remain open" — checked section 6's own checkboxes in `robot_side_verification_todo.md` and confirmed the exhaustive 3-rep measured protocol really is still unchecked, so that part wasn't stale.
  - CONTRIBUTING's "Close validation gates" priority bullet described sections 1-6 as not started; reworded to name only what's actually still open.
  - `context.md`'s "Hardware gate still outstanding" described the one-time platform gate as still pending; reframed as done for the code, with a pointer to the new guide for additional units. Its "Current Git state" also still named `platform/simulator-parity` as "the implementation branch" and autostart as "blocked."
- `docs/autostart_setup.md`: updated its precondition paragraph (no longer requires repeating x3-c's checklist) and fixed one internal section link that the renumbering broke (`#4-identify-required-hardware` → `#3-identify-this-robots-hardware`).

## What's deliberately *not* touched

`docs/robot_side_verification_todo.md` and `docs/robot_side_next_moves.md` stay as-is — they're `x3-c`-specific historical records of how that robot got through the one-time gate, not living setup instructions, matching how `agents/` is already treated in this repo.

## Verification

Grepped the whole repo afterward for dangling references to what got removed (`motor_live_loss_probe`/`rosmaster-recovery-evidence` outside the CI test list, old section-anchor links like `#4-identify-required-hardware`, `#9-autostart-decision`) and fixed what turned up. Re-read every edited section in context rather than trusting isolated diffs.

## Test plan

- [ ] Someone who's actually set up a robot from these docs before confirms the trimmed guide still has everything needed to bring one up
- [ ] Sanity-check that I didn't drop something safety-relevant that should've stayed — this was a judgment call about the exact per-robot/per-code line, made per the owner's explicit direction, but worth a second look given it's a real robot
