### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+<!-- What changed, and why. -->
+
+## Runtime behavior
+
+<!-- Does this change a launch arg, topic, or driver default? If yes, say so
+explicitly — this affects a shared physical robot. -->
+
+- [ ] No runtime behavior change
+- [ ] Runtime behavior changes (described above)
+
+## Safety-relevant?
+
+<!-- Does this touch motor commands, safety limits, watchdogs, or timeout
+behavior? If yes, call it out clearly so reviewers check it carefully. -->
+
+- [ ] No
+- [ ] Yes (described above)
+
+## Verification
+
+<!-- How did you verify this? Be precise about validation status — if
+something is floor-tested but not ground-truth-verified, say so rather than
+overstating it. -->
+
+- [ ] Workstation build + `colcon test` pass
+- [ ] Robot-side validation completed (required for motion/driver/odometry
+      changes — see `docs/robot_side_verification_todo.md` and
+      `docs/odometry_validation.md`)
+- [ ] N/A — no robot-side validation needed
+
+## Test plan
+
+<!-- What a reviewer should check, or what you ran. -->
+
+## Related issues
+
+<!-- Fixes #, Closes #, Related to # -->


### PR DESCRIPTION
## Summary

No repo in the org has a PR template, so PR descriptions vary in whether
they cover what CONTRIBUTING.md already asks contributors to do: call out
runtime-behavior changes, flag safety-relevant changes, and describe
verification honestly (e.g. floor-tested vs. ground-truth-verified). This
adds `.github/pull_request_template.md` mirroring those sections so the
GitHub PR composer prompts for them directly instead of relying on
contributors re-reading CONTRIBUTING.md each time.

## Runtime behavior

- [x] No runtime behavior change

## Safety-relevant?

- [x] No

## Verification

- [x] N/A — no robot-side validation needed (docs-only change)

## Test plan

- Open a new PR against this branch's base and confirm GitHub pre-fills
  the description from the template.

## Related issues

N/A